### PR TITLE
docs: Swagger 문서화 추가(Todo, Block 기능)

### DIFF
--- a/src/block/block.controller.ts
+++ b/src/block/block.controller.ts
@@ -1,27 +1,53 @@
-import { Controller, Get, Post, Param, Delete, Body } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Delete,
+  Body,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiParam,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { BlockService } from './block.service';
 import { CreateBlockDto } from './dtos/create-block.dto';
 
+@ApiTags('Block') // Swagger UI에서 이 컨트롤러는 "Block" 그룹으로 표시됨
+@ApiBearerAuth('access-token') // JWT 토큰 입력을 요구함
 @Controller('block')
 export class BlockController {
   constructor(private readonly blockService: BlockService) {}
 
   @Post()
+  @ApiOperation({ summary: '웹사이트 차단 등록' })
+  @ApiResponse({ status: 201, description: '차단 사이트 등록 완료' })
   create(@Body() dto: CreateBlockDto) {
     return this.blockService.create(dto);
   }
 
   @Get()
+  @ApiOperation({ summary: '차단된 사이트 전체 조회' })
+  @ApiResponse({ status: 200, description: '전체 차단 목록 반환' })
   findAll() {
     return this.blockService.findAll();
   }
 
   @Get(':id')
+  @ApiOperation({ summary: '특정 차단 항목 조회' })
+  @ApiParam({ name: 'id', description: '차단 ID' })
+  @ApiResponse({ status: 200, description: 'ID에 해당하는 차단 항목 반환' })
   findOne(@Param('id') id: string) {
     return this.blockService.findOne(+id);
   }
 
   @Delete(':id')
+  @ApiOperation({ summary: '차단 해제 (삭제)' })
+  @ApiParam({ name: 'id', description: '차단 해제할 ID' })
+  @ApiResponse({ status: 200, description: '삭제 완료' })
   remove(@Param('id') id: string) {
     return this.blockService.remove(+id);
   }

--- a/src/block/dtos/create-block.dto.ts
+++ b/src/block/dtos/create-block.dto.ts
@@ -1,15 +1,18 @@
-import { IsString, IsInt, IsDateString } from 'class-validator';
+import { IsString, IsInt } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateBlockDto {
-    @IsString()
-    url: string;
+  @ApiProperty({
+    example: 'https://www.youtube.com',
+    description: '차단할 웹사이트의 URL',
+  })
+  @IsString()
+  url: string;
 
-    @IsInt()
-    userId: number;
-
-    @IsDateString()
-    startTime: string;
-
-    @IsDateString()
-    endTime: string;
+  @ApiProperty({
+    example: 1,
+    description: '차단을 등록한 사용자 ID',
+  })
+  @IsInt()
+  userId: number;
 }

--- a/src/todo/dtos/create-todo.dto.ts
+++ b/src/todo/dtos/create-todo.dto.ts
@@ -1,12 +1,25 @@
 import { IsString, IsInt, IsBoolean } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateTodoDto {
+  @ApiProperty({
+    example: '운동하기',
+    description: '할 일의 내용',
+  })
   @IsString()
   content: string;
 
+  @ApiProperty({
+    example: 1,
+    description: '할 일을 등록한 사용자 ID',
+  })
   @IsInt()
   userId: number;
 
+  @ApiProperty({
+    example: false,
+    description: '할 일 완료 여부 (true: 완료, false: 미완료)',
+  })
   @IsBoolean()
   isDone: boolean;
 }

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -1,27 +1,40 @@
 import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiParam, } from '@nestjs/swagger';
 import { TodoService } from './todo.service';
 import { CreateTodoDto } from './dtos/create-todo.dto';
 
+@ApiTags('Todo')
+@ApiBearerAuth('access-token')
 @Controller('todo')
 export class TodoController {
   constructor(private readonly todoService: TodoService) {}
 
   @Post()
+  @ApiOperation({ summary: '할 일 생성'})
+  @ApiResponse({ status: 201, description: '할 일 생성 성공'})
   create(@Body() dto: CreateTodoDto) {
     return this.todoService.create(dto);
   }
 
-  @Get()
+ @Get()
+  @ApiOperation({ summary: '전체 할 일 조회' })
+  @ApiResponse({ status: 200, description: '모든 할 일 반환' })
   findAll() {
     return this.todoService.findAll();
   }
 
   @Get(':id')
+  @ApiOperation({ summary: '특정 할 일 조회' })
+  @ApiParam({ name: 'id', description: '할 일 ID' })
+  @ApiResponse({ status: 200, description: '해당 ID의 할 일 반환' })
   findOne(@Param('id') id: string) {
     return this.todoService.findOne(+id);
   }
 
   @Delete(':id')
+  @ApiOperation({ summary: '할 일 삭제' })
+  @ApiParam({ name: 'id', description: '삭제할 할 일 ID' })
+  @ApiResponse({ status: 200, description: '삭제 완료' })
   remove(@Param('id') id: string) {
     return this.todoService.remove(+id);
   }


### PR DESCRIPTION
Todo랑 Block 기능에 Swagger 문서화 작업 추가했습니다.
각 API에 설명/예제 붙여서 Swagger UI에서 바로 테스트 가능하게 정리했습니다.

**주요 변경 내용**
TodoController, BlockController에 Swagger 데코레이터 추가 (@ApiTags, @ApiOperation, @ApiResponse 등)

CreateTodoDto, CreateBlockDto에 @ApiProperty 추가

JWT 인증이 필요한 API는 @ApiBearerAuth('access-token') 사용

**테스트**
Swagger UI에서 POST, GET, DELETE 전부 정상 작동 확인

요청 예제와 설명 잘 표시됨

JWT 토큰 인증 포함된 상태에서 테스트 완료

기능 문서화 작업이어서 따로 브랜치 파서 PR 올립니다.